### PR TITLE
fixbug编译报错

### DIFF
--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -24,6 +24,7 @@ module.exports = {
             react: path.join(__dirname, 'node_modules/react/dist/react-with-addons.min'),
             redux: path.join(__dirname, 'node_modules/redux/dist/redux.min'),
             'react-dom': path.join(__dirname, 'node_modules/react-dom/dist/react-dom.min'),
+            'react-slick': path.join(__dirname, 'node_modules/react-slick/dist/react-slick.min'),
             'react-proxy': path.join(__dirname, 'node_modules/react-proxy/dist/ReactProxy'),
             'react-redux': path.join(__dirname, 'node_modules/react-redux/dist/react-redux.min'),
             'react-router': path.join(__dirname, 'node_modules/react-router/umd/ReactRouter.min'),


### PR DESCRIPTION
ERROR in ./~/react-slick/lib/mixins/helpers.js
Module not found: Error: Cannot resolve 'file' or 'directory' /Users/janeluck/webapp/practices/node_modules/react/dist/react-with-addons.min/lib/ReactTransitionEvents in /Users/janeluck/webapp/practices/node_modules/react-slick/lib/mixins
 @ ./~/react-slick/lib/mixins/helpers.js 17:37-79